### PR TITLE
Removed team member from Electrical

### DIFF
--- a/components/Teams.jsx
+++ b/components/Teams.jsx
@@ -14,7 +14,6 @@ const teams = [
     "Roger Teng",
     "Kyle Ludwig",
     "Aaron Chau",
-    "Eric Shu",
     "Roger Teng",
     "Zerong Cai",
     "Hugo Jr Gonzalez Cantu",


### PR DESCRIPTION
Removed Eric Shu from the Electrical team column on the team's page. Issue #110 